### PR TITLE
fix(home): Propagate auth errors to trigger token refresh

### DIFF
--- a/src/app/features/home/home.component.ts
+++ b/src/app/features/home/home.component.ts
@@ -16,7 +16,7 @@ import {
 import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { Title, Meta } from '@angular/platform-browser';
 import { TranslocoService, TranslocoModule } from '@ngneat/transloco';
-import { Subscription, of } from 'rxjs';
+import { Subscription, of, throwError } from 'rxjs';
 import { catchError, finalize, take, map } from 'rxjs/operators';
 import { RouterModule } from '@angular/router';
 import { HttpParams } from '@angular/common/http';
@@ -142,7 +142,8 @@ export class HomeComponent implements OnInit, OnDestroy, AfterViewInit {
           this.errorBestsellers.set(
             this.translocoService.translate('home.errorLoadingBestsellers')
           );
-          return of([]);
+          // Wir werfen den Fehler weiter, damit der Interceptor ihn fangen kann
+          return throwError(() => err);
         }),
         finalize(() => {
           this.isLoadingBestsellers.set(false);


### PR DESCRIPTION
On the home page, the `loadBestsellers` method was catching API errors (such as 403 Forbidden on expired JWTs) and returning an empty observable (`of([])`).

This "swallowed" the error, preventing the `AuthHttpInterceptor` from detecting the invalid token state. As a result, the token refresh mechanism was never triggered, and the user would see an error state instead of the content loading after a brief delay.

This change modifies the `catchError` block to re-throw the error. This allows the interceptor to catch the error, handle the token refresh, and automatically retry the failed request, which resolves the bug.