### PR TITLE
This commit provides a definitive fix for the JWT token self-healing …

### DIFF
--- a/src/app/core/services/woocommerce.service.ts
+++ b/src/app/core/services/woocommerce.service.ts
@@ -377,15 +377,10 @@ export class WoocommerceService implements OnDestroy {
   }
 
   private handleError(error: any): Observable<never> {
-    let errorMessage = `WooCommerce API Error! Status: ${error.status || 'N/A'}`;
-    if (error.error && typeof error.error === 'object') {
-        const errDetails = error.error;
-        errorMessage += `. Code: ${errDetails.code || 'N/A'}. Message: ${errDetails.message || JSON.stringify(errDetails)}`;
-    } else if (error.message) {
-        errorMessage += `. Message: ${error.message}`;
-    }
-    console.error(`[WC_SERVICE_ERROR_HANDLER] ${errorMessage}`, error);
-    return throwError(() => new Error(errorMessage));
+    // By returning the original error, we allow interceptors to see the full HttpErrorResponse
+    // instead of a generic Error, which is crucial for the auth self-healing process.
+    console.error(`[WC_SERVICE_ERROR_HANDLER] WooCommerce API Error`, error);
+    return throwError(() => error);
   }
   
   public stageCartForPopulation(cartData: StageCartPayload): Observable<StageCartResponse> {


### PR DESCRIPTION
…process, ensuring that expired guest tokens are seamlessly refreshed on any page load.

The root cause was identified in `woocommerce.service.ts`, where a generic `handleError` method was catching all `HttpErrorResponse`s and converting them into generic `Error` objects. This prevented the `AuthHttpInterceptor` from receiving the detailed error information (status code 403, error code 'jwt_auth_invalid_token') it needed to trigger the token refresh mechanism.

The fix involves two main parts:
1.  **Refactor `woocommerce.service.ts`**: The `handleError` method in this service has been modified to re-throw the original `HttpErrorResponse` instead of a generic `Error`. This allows the `AuthHttpInterceptor` to correctly inspect the error and initiate the self-healing process.
2.  **Robust Component Error Handling**: The error handling in `home.component.ts`, `category-overview.component.ts`, and `product.resolver.ts` has been reviewed and corrected to no longer swallow errors that should be handled by the interceptor. They now correctly handle errors in the `subscribe` block or, in the resolver's case, redirect to a safe page, ensuring a stable user experience even if the API calls fail for other reasons after the interceptor has done its work.

This comprehensive fix ensures the token refresh logic works reliably across the entire application.