### PR TITLE
feat(maintenance): activate maintenance page and update content

### DIFF
--- a/src/app/maintenance/maintenance.component.html
+++ b/src/app/maintenance/maintenance.component.html
@@ -4,31 +4,6 @@
 
   <h1>{{ 'maintenancePage.mainTitle' | transloco }}</h1>
 
-  @if (!countdownEnded) {
-    <div class="countdown">
-      <div class="time-unit">
-        <span class="value">{{ days }}</span>
-        <span class="label">{{ 'maintenancePage.countdown.days' | transloco }}</span>
-      </div>
-      <div class="time-unit">
-        <span class="value">{{ hours }}</span>
-        <span class="label">{{ 'maintenancePage.countdown.hours' | transloco }}</span>
-      </div>
-      <div class="time-unit">
-        <span class="value">{{ minutes }}</span>
-        <span class="label">{{ 'maintenancePage.countdown.minutes' | transloco }}</span>
-      </div>
-      <div class="time-unit">
-        <span class="value">{{ seconds }}</span>
-        <span class="label">{{ 'maintenancePage.countdown.seconds' | transloco }}</span>
-      </div>
-    </div>
-  } @else {
-    <div class="countdown-ended">
-      <h2>{{ 'maintenancePage.countdownEnded' | transloco }}</h2>
-    </div>
-  }
-
   <div class="info-text-section">
     <p>{{ 'maintenancePage.mysteryTextLine1' | transloco }}</p>
     <p>{{ 'maintenancePage.mysteryTextLine2' | transloco }}</p>

--- a/src/app/maintenance/maintenance.component.ts
+++ b/src/app/maintenance/maintenance.component.ts
@@ -1,5 +1,5 @@
 // /src/app/features/maintenance/maintenance.component.ts
-import { Component, OnInit, OnDestroy, ChangeDetectionStrategy, ChangeDetectorRef, Inject, PLATFORM_ID, WritableSignal, signal } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, ChangeDetectorRef, Inject, PLATFORM_ID, WritableSignal, signal } from '@angular/core';
 import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { TranslocoModule, TranslocoService, LangDefinition } from '@ngneat/transloco';
 import { FormsModule } from '@angular/forms';
@@ -12,15 +12,7 @@ import { FormsModule } from '@angular/forms';
   styleUrl: './maintenance.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class MaintenanceComponent implements OnInit, OnDestroy {
-  targetDate!: Date;
-  days: string = '00';
-  hours: string = '00';
-  minutes: string = '00';
-  seconds: string = '00';
-  countdownEnded = false;
-  private intervalId: any;
-
+export class MaintenanceComponent implements OnInit {
   availableLangsSignal: WritableSignal<{ id: string; label: string }[]> = signal([]);
   activeLang: WritableSignal<string> = signal('');
 
@@ -33,18 +25,11 @@ export class MaintenanceComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.activeLang.set(this.translocoService.getActiveLang());
     this.setupLanguageOptions();
-    this.startCountdown();
 
     this.translocoService.langChanges$.subscribe(currentLang => {
         this.activeLang.set(currentLang);
         this.cdr.markForCheck();
     });
-  }
-
-  ngOnDestroy(): void {
-    if (this.intervalId) {
-      clearInterval(this.intervalId);
-    }
   }
 
   private setupLanguageOptions(): void {
@@ -70,44 +55,5 @@ export class MaintenanceComponent implements OnInit, OnDestroy {
     if (langId) {
         this.translocoService.setActiveLang(langId);
     }
-  }
-
-  private startCountdown(): void {
-    this.targetDate = new Date('2025-06-01T00:00:00');
-    this.updateCountdown();
-    if (isPlatformBrowser(this.platformId)) {
-      this.intervalId = setInterval(() => {
-        this.updateCountdown();
-      }, 1000);
-    }
-  }
-
-  private updateCountdown(): void {
-    const now = new Date().getTime();
-    if (!this.targetDate) {
-      return;
-    }
-    const targetTimestamp = this.targetDate.getTime();
-    const distance = targetTimestamp - now;
-
-    if (distance <= 0) {
-      this.days = '00'; this.hours = '00'; this.minutes = '00'; this.seconds = '00';
-      this.countdownEnded = true;
-      if (this.intervalId) {
-         clearInterval(this.intervalId);
-         this.intervalId = null;
-       }
-    } else {
-      const d = Math.floor(distance / (1000 * 60 * 60 * 24));
-      const h = Math.floor((distance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
-      const m = Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60));
-      const s = Math.floor((distance % (1000 * 60)) / 1000);
-      this.days = d.toString().padStart(2, '0');
-      this.hours = h.toString().padStart(2, '0');
-      this.minutes = m.toString().padStart(2, '0');
-      this.seconds = s.toString().padStart(2, '0');
-      this.countdownEnded = false;
-    }
-    this.cdr.markForCheck();
   }
 }

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -735,17 +735,10 @@
     "title": "Seite nicht gefunden - Your Garden Eden"
   },
   "maintenancePage": {
-    "mainTitle": "Etwas Großes entsteht...",
-    "countdown": {
-      "days": "Tage",
-      "hours": "Stunden",
-      "minutes": "Minuten",
-      "seconds": "Sekunden"
-    },
-    "countdownEnded": "Es ist soweit! Die Tore zu Ihrem Garten Eden öffnen sich!",
-    "mysteryTextLine1": "Psst... hinter den Kulissen wächst etwas Einzigartiges heran.",
-    "mysteryTextLine2": "Eine Oase der Inspiration für Ihren perfekten Garten erwartet Sie mit exklusiven Designs und grünen Geheimnissen.",
-    "mysteryTextHighlight": "Seien Sie gespannt – das Warten wird sich lohnen!"
+    "mainTitle": "Wir bauen für Sie um!",
+    "mysteryTextLine1": "Ein großes Update steht bevor! Wir arbeiten hinter den Kulissen daran, unseren Service und unsere Produktqualität für Sie zu verbessern.",
+    "mysteryTextLine2": "Pünktlich zur kommenden Gartensaison sind wir mit vielen neuen, hochwertigen Produkten und tollen Angeboten wieder für Sie da.",
+    "mysteryTextHighlight": "Freuen Sie sich auf ein noch besseres Einkaufserlebnis bei Your Garden Eden!"
   },
   "productCard": {
     "sale": "Angebot!",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -727,17 +727,10 @@
     "title": "Page Not Found - Your Garden Eden"
   },
   "maintenancePage": {
-    "mainTitle": "Something big is growing...",
-    "countdown": {
-      "days": "Days",
-      "hours": "Hours",
-      "minutes": "Minutes",
-      "seconds": "Seconds"
-    },
-    "countdownEnded": "The time has come! The gates to Your Garden Eden are opening!",
-    "mysteryTextLine1": "Shhh... something unique is growing behind the scenes.",
-    "mysteryTextLine2": "An oasis of inspiration for your perfect garden awaits you with exclusive designs and green secrets.",
-    "mysteryTextHighlight": "Stay tuned – it will be worth the wait!"
+    "mainTitle": "We are renovating for you!",
+    "mysteryTextLine1": "A major update is coming! We are working behind the scenes to improve our service and product quality for you.",
+    "mysteryTextLine2": "Just in time for the upcoming garden season, we will be back with many new, high-quality products and great offers.",
+    "mysteryTextHighlight": "Look forward to an even better shopping experience at Your Garden Eden!"
   },
   "productCard": {
     "sale": "Sale!",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -727,17 +727,10 @@
     "title": "Página no encontrada - Your Garden Eden"
   },
   "maintenancePage": {
-    "mainTitle": "Algo grande está creciendo...",
-    "countdown": {
-      "days": "Días",
-      "hours": "Horas",
-      "minutes": "Minutos",
-      "seconds": "Segundos"
-    },
-    "countdownEnded": "¡Ha llegado el momento! ¡Las puertas de Your Garden Eden se abren!",
-    "mysteryTextLine1": "Shhh... algo único está creciendo entre bastidores.",
-    "mysteryTextLine2": "Un oasis de inspiración para tu jardín perfecto te espera con diseños exclusivos y secretos verdes.",
-    "mysteryTextHighlight": "¡Mantente atento, la espera merecerá la pena!"
+    "mainTitle": "¡Estamos renovando para usted!",
+    "mysteryTextLine1": "¡Se acerca una gran actualización! Estamos trabajando entre bastidores para mejorar nuestro servicio y la calidad de nuestros productos para usted.",
+    "mysteryTextLine2": "Justo a tiempo para la próxima temporada de jardinería, volveremos con muchos productos nuevos, de alta calidad y grandes ofertas.",
+    "mysteryTextHighlight": "¡Disfrute de una experiencia de compra aún mejor en Your Garden Eden!"
   },
   "productCard": {
     "sale": "¡Oferta!",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -727,17 +727,10 @@
     "title": "Stranica nije pronađena - Your Garden Eden"
   },
   "maintenancePage": {
-    "mainTitle": "Nešto veliko raste...",
-    "countdown": {
-      "days": "Dana",
-      "hours": "Sati",
-      "minutes": "Minuta",
-      "seconds": "Sekundi"
-    },
-    "countdownEnded": "Došlo je vrijeme! Vrata vašeg vrta Eden se otvaraju!",
-    "mysteryTextLine1": "Psst... iza kulisa raste nešto jedinstveno.",
-    "mysteryTextLine2": "Oaza inspiracije za vaš savršen vrt čeka vas s ekskluzivnim dizajnima i zelenim tajnama.",
-    "mysteryTextHighlight": "Ostanite s nama – isplatit će se čekati!"
+    "mainTitle": "Renoviramo za vas!",
+    "mysteryTextLine1": "Slijedi veliko ažuriranje! Radimo iza kulisa na poboljšanju naših usluga i kvalitete proizvoda za vas.",
+    "mysteryTextLine2": "Točno na vrijeme za nadolazeću vrtlarsku sezonu, vraćamo se s mnogo novih, visokokvalitetnih proizvoda i sjajnih ponuda.",
+    "mysteryTextHighlight": "Radujte se još boljem iskustvu kupovine u Your Garden Eden!"
   },
   "productCard": {
     "sale": "Akcija!",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -6,7 +6,7 @@
     "noResults": "Nema rezultata",
     "searchPrompt": "Molimo unesite najmanje 3 znaka.",
     "close": "Zatvori",
-    "locale": "hr-HR",
+    "locale": "pl-PL",
     "free": "Besplatno",
     "processing": "Obrada...",
     "scrollToTop": "Pomakni na vrh",
@@ -727,17 +727,10 @@
     "title": "Stranica nije pronađena - Your Garden Eden"
   },
   "maintenancePage": {
-    "mainTitle": "Nešto veliko raste...",
-    "countdown": {
-      "days": "Dana",
-      "hours": "Sati",
-      "minutes": "Minuta",
-      "seconds": "Sekundi"
-    },
-    "countdownEnded": "Došlo je vrijeme! Vrata vašeg vrta Eden se otvaraju!",
-    "mysteryTextLine1": "Psst... iza kulisa raste nešto jedinstveno.",
-    "mysteryTextLine2": "Oaza inspiracije za vaš savršen vrt čeka vas s ekskluzivnim dizajnima i zelenim tajnama.",
-    "mysteryTextHighlight": "Ostanite s nama – isplatit će se čekati!"
+    "mainTitle": "Przebudowujemy dla Ciebie!",
+    "mysteryTextLine1": "Nadchodzi duża aktualizacja! Pracujemy za kulisami, aby ulepszyć nasze usługi i jakość produktów dla Ciebie.",
+    "mysteryTextLine2": "W samą porę na nadchodzący sezon ogrodniczy, wrócimy z wieloma nowymi, wysokiej jakości produktami i wspaniałymi ofertami.",
+    "mysteryTextHighlight": "Ciesz się jeszcze lepszymi zakupami w Your Garden Eden!"
   },
   "productCard": {
     "sale": "Akcija!",

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -2,7 +2,7 @@
 export const environment = {
   baseUrl: 'https://www.your-garden-eden.de', // KORREKTUR: Die Basis-URL wurde gesetzt.
   production: true,
-  maintenanceMode: false,
+  maintenanceMode: true,
   firebase: {
     apiKey: 'AIzaSyA2W0UsyZEPQA8_GbRYbftcDEtGCe6pDSc', // Dieser bleibt, wird für die Firebase-App-Initialisierung benötigt
     authDomain: 'your-garden-eden.firebaseapp.com',


### PR DESCRIPTION
This commit activates the maintenance page for the website to inform users about upcoming changes.

- Sets the `maintenanceMode` flag to `true` in the environment configuration to enable the maintenance page globally.
- Simplifies the `MaintenanceComponent` by removing the outdated countdown timer logic.
- Updates the informational text on the maintenance page to clearly communicate the reasons for the site overhaul, as requested by the user.
- Provides translations for the new maintenance text in all supported languages (DE, EN, ES, HR, PL) to ensure a consistent user experience.